### PR TITLE
Add new timeToInteractive custom-metric JS snippet

### DIFF
--- a/custom_metrics/timeToInteractive.js
+++ b/custom_metrics/timeToInteractive.js
@@ -1,0 +1,1 @@
+return window.performance.timing.timeToInteractive;


### PR DESCRIPTION
This gets us ready for collecting and reporting on ```timeToInteractive```, which should land soon in Firefox Nightly: https://bugzilla.mozilla.org/show_bug.cgi?id=1299118

See also https://github.com/WPO-Foundation/wptagent/pull/190 for the ```wptagent```-proposed changes.

@jbuck r?