### PR TITLE
Bug 1458452: Keep tests locally for 30 days, before archiving to our S3 bucket

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -1,5 +1,5 @@
 [settings]
-product=WebPagetest
+product=WebPageTest
 contact=jbuckley@mozilla.com
 ; Disable "HTTP Basic Authentication" ui
 no_basic_auth_ui=1
@@ -51,7 +51,7 @@ archive_s3_key=${S3_KEY}
 archive_s3_secret=${S3_SECRET}
 archive_s3_bucket=${S3_BUCKET}
 ;Number of days to keep tests locally before archiving
-archive_days=0
+archive_days=30
 
 ; EC2 Instances
 ec2_locations=1


### PR DESCRIPTION
Cross-reference with the public-instance config (sample): https://github.com/WPO-Foundation/webpagetest/blob/39cf55040609de897e9709e193c23130b6600a70/www/settings/settings.ini.sample#L227-L228

/cc @davehunt for awareness